### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-documentation=true


### PR DESCRIPTION
Suggesting this because currently GitHub linguist classifies this repo as html (see https://github.com/github/linguist#overrides for more info about linguist overrides). 