### PR TITLE
robust rbind

### DIFF
--- a/R/get_inat_obs.R
+++ b/R/get_inat_obs.R
@@ -142,7 +142,7 @@ get_inat_obs <- function(query=NULL,taxon_name = NULL,taxon_id = NULL,quality=NU
       page_query <- paste(search,"&per_page=200&page=",i,sep="")
       data <-  GET(base_url,path = q_path, query = page_query)
       data <- inat_handle(data)
-      data_out <- rbind(data_out, read.csv(textConnection(data), stringsAsFactors = FALSE))
+      data_out <- plyr::rbind.fill(data_out, read.csv(textConnection(data), stringsAsFactors = FALSE))
     }
   }
   
@@ -150,7 +150,11 @@ get_inat_obs <- function(query=NULL,taxon_name = NULL,taxon_id = NULL,quality=NU
     if(maxresults < dim(data_out)[1]){
       data_out <- data_out[1:maxresults,]
     }
+    if(length(grep("X..DOCTYPE.html.",names(data_out)))>0){
+      data_out <- data_out[,ncol(data_out)] ## take off end
+    }
   }
+  
 
   if(meta){ 
     return(list(meta=list(found=total_res, returned=nrow(data_out)), data=data_out)) 

--- a/R/get_inat_obs.R
+++ b/R/get_inat_obs.R
@@ -150,9 +150,7 @@ get_inat_obs <- function(query=NULL,taxon_name = NULL,taxon_id = NULL,quality=NU
     if(maxresults < dim(data_out)[1]){
       data_out <- data_out[1:maxresults,]
     }
-    if(length(grep("X..DOCTYPE.html.",names(data_out)))>0){
-      data_out <- data_out[,ncol(data_out)] ## take off end
-    }
+    
   }
   
 

--- a/R/get_inat_obs.R
+++ b/R/get_inat_obs.R
@@ -153,7 +153,8 @@ get_inat_obs <- function(query=NULL,taxon_name = NULL,taxon_id = NULL,quality=NU
     
   }
   
-
+  data_out <- data_out[,1:38] ## remove the extra column if one is added by the fill
+  
   if(meta){ 
     return(list(meta=list(found=total_res, returned=nrow(data_out)), data=data_out)) 
   } else { return(data_out) }

--- a/R/get_inat_obs_project.R
+++ b/R/get_inat_obs_project.R
@@ -51,8 +51,9 @@ get_inat_obs_project <- function(grpid,type = c("observations","info"), raw = F)
     url1=paste("http://www.inaturalist.org/observations/project/",grpid,".csv?page=",i,"&per_page=100",sep="")
     cat(paste("-",i*100,sep=""))
     newdat=read.csv(url1,stringsAsFactors = FALSE)
-    dat=plyr::rbind.fill(dat,newdat)
+    dat=rbind(dat,newdat)
   }
+    
   return(dat)
 }
   

--- a/R/get_inat_obs_project.R
+++ b/R/get_inat_obs_project.R
@@ -51,7 +51,7 @@ get_inat_obs_project <- function(grpid,type = c("observations","info"), raw = F)
     url1=paste("http://www.inaturalist.org/observations/project/",grpid,".csv?page=",i,"&per_page=100",sep="")
     cat(paste("-",i*100,sep=""))
     newdat=read.csv(url1,stringsAsFactors = FALSE)
-    dat=rbind(dat,newdat)
+    dat=plyr::rbind.fill(dat,newdat)
   }
   return(dat)
 }

--- a/R/get_inat_obs_user.R
+++ b/R/get_inat_obs_user.R
@@ -44,9 +44,6 @@ get_inat_obs_user <- function(username,maxresults=100){
     data_out <- data_out[1:maxresults,]
   }
   
-  if(length(grep("X..DOCTYPE.html.",names(data_out)))>0){
-    data_out <- data_out[,ncol(data_out)] ## take off end
-  }
   
   return(data_out)
 }

--- a/R/get_inat_obs_user.R
+++ b/R/get_inat_obs_user.R
@@ -44,6 +44,7 @@ get_inat_obs_user <- function(username,maxresults=100){
     data_out <- data_out[1:maxresults,]
   }
   
+  data_out <- data_out[,1:38] ## remove the extra column if one is added by the fill
   
   return(data_out)
 }

--- a/R/get_inat_obs_user.R
+++ b/R/get_inat_obs_user.R
@@ -35,7 +35,7 @@ get_inat_obs_user <- function(username,maxresults=100){
     for(i in 2:ceiling(total_res/200)){
       page_query <- paste("&per_page=200&page=",i,sep="")
       dat <-  GET(base_url,path = paste("observations/",q_path,sep=""), query = page_query)
-      data_out <- rbind.fill(data_out, read.csv(textConnection(content(dat, as = "text"))))
+      data_out <- plyr::rbind.fill(data_out, read.csv(textConnection(content(dat, as = "text"))))
     }
     
   }

--- a/R/get_inat_obs_user.R
+++ b/R/get_inat_obs_user.R
@@ -44,5 +44,9 @@ get_inat_obs_user <- function(username,maxresults=100){
     data_out <- data_out[1:maxresults,]
   }
   
+  if(length(grep("X..DOCTYPE.html.",names(data_out)))>0){
+    data_out <- data_out[,ncol(data_out)] ## take off end
+  }
+  
   return(data_out)
 }

--- a/R/get_inat_obs_user.R
+++ b/R/get_inat_obs_user.R
@@ -35,7 +35,7 @@ get_inat_obs_user <- function(username,maxresults=100){
     for(i in 2:ceiling(total_res/200)){
       page_query <- paste("&per_page=200&page=",i,sep="")
       dat <-  GET(base_url,path = paste("observations/",q_path,sep=""), query = page_query)
-      data_out <- rbind(data_out, read.csv(textConnection(content(dat, as = "text"))))
+      data_out <- rbind.fill(data_out, read.csv(textConnection(content(dat, as = "text"))))
     }
     
   }


### PR DESCRIPTION
For some queries I was getting: `Error in rbind(deparse.level, ...) : numbers of columns of arguments do not match` 

I changed the rbinds in `get_inat_obs()`, `get_inat_obs_project()`, and `get_inat_obs_user()` to `plyr::rbind_fill()` to get around this.

For `get_inat_obs()` and `get_inat_obs_user()` I also added a line to remove the extra fill column that arises if the fill occurs.

This does not involve any new dependencies since plyr is already used in the package. 