### PR TITLE
Add place_id argument to get_inat_obs

### DIFF
--- a/R/get_inat_obs.R
+++ b/R/get_inat_obs.R
@@ -9,6 +9,7 @@
 #' descendant taxa. Note that names are not unique, so if the name matches multiple taxa, no
 #' observations may be returned.
 #' @param taxon_id Filter by iNat taxon ID. Note that this will also select observations of descendant taxa.
+#' @param place_id Filter by iNat place ID.
 #' @param geo Flag for returning only results that are georeferenced, TRUE will exclude
 #' non-georeferenced results, but they cannot be excluded.
 #' @param year Return observations only in that year (can only be one year, not a range of years).
@@ -47,13 +48,14 @@
 #' @export
 
 get_inat_obs <- function(query = NULL, taxon_name = NULL, taxon_id = NULL,
-                         quality = NULL, geo = NULL, year = NULL, month = NULL,
-                         day = NULL, bounds = NULL, maxresults = 100, meta = FALSE)
+                         place_id, quality = NULL, geo = NULL, year = NULL,
+                         month = NULL, day = NULL, bounds = NULL, 
+                         maxresults = 100, meta = FALSE)
 {
 
   ## Parsing and error-handling of input strings
-  arg_list <- list(query, taxon_name, taxon_id, quality, geo,
-                year, month, day, bounds)
+  arg_list <- list(query, taxon_name, taxon_id, place_id, quality, geo,
+                   year, month, day, bounds)
   arg_vals <- lapply(arg_list, is.null)
   if (all(unlist(arg_vals))) {
     stop("All search parameters NULL. Please provide at least one.")
@@ -77,6 +79,10 @@ get_inat_obs <- function(query = NULL, taxon_name = NULL, taxon_id = NULL,
 
   if(!is.null(taxon_id)){
     search <-  paste0(search, "&taxon_id=", gsub(" ","+", taxon_id))
+  }
+  
+  if(!is.null(place_id)){
+    search <-  paste0(search, "&place_id=", gsub(" ","+", place_id))
   }
 
 

--- a/R/get_inat_obs.R
+++ b/R/get_inat_obs.R
@@ -48,8 +48,8 @@
 #' @export
 
 get_inat_obs <- function(query = NULL, taxon_name = NULL, taxon_id = NULL,
-                         place_id, quality = NULL, geo = NULL, year = NULL,
-                         month = NULL, day = NULL, bounds = NULL, 
+                         place_id = NULL, quality = NULL, geo = NULL,
+                         year = NULL, month = NULL, day = NULL, bounds = NULL,
                          maxresults = 100, meta = FALSE)
 {
 
@@ -80,7 +80,7 @@ get_inat_obs <- function(query = NULL, taxon_name = NULL, taxon_id = NULL,
   if(!is.null(taxon_id)){
     search <-  paste0(search, "&taxon_id=", gsub(" ","+", taxon_id))
   }
-  
+
   if(!is.null(place_id)){
     search <-  paste0(search, "&place_id=", gsub(" ","+", place_id))
   }

--- a/man/get_inat_obs.Rd
+++ b/man/get_inat_obs.Rd
@@ -5,8 +5,9 @@
 \title{Download iNaturalist data}
 \usage{
 get_inat_obs(query = NULL, taxon_name = NULL, taxon_id = NULL,
-  place_id, quality = NULL, geo = NULL, year = NULL, month = NULL,
-  day = NULL, bounds = NULL, maxresults = 100, meta = FALSE)
+  place_id = NULL, quality = NULL, geo = NULL, year = NULL,
+  month = NULL, day = NULL, bounds = NULL, maxresults = 100,
+  meta = FALSE)
 }
 \arguments{
 \item{query}{Query string for a general search.}

--- a/man/get_inat_obs.Rd
+++ b/man/get_inat_obs.Rd
@@ -5,7 +5,7 @@
 \title{Download iNaturalist data}
 \usage{
 get_inat_obs(query = NULL, taxon_name = NULL, taxon_id = NULL,
-  quality = NULL, geo = NULL, year = NULL, month = NULL,
+  place_id, quality = NULL, geo = NULL, year = NULL, month = NULL,
   day = NULL, bounds = NULL, maxresults = 100, meta = FALSE)
 }
 \arguments{
@@ -16,6 +16,8 @@ descendant taxa. Note that names are not unique, so if the name matches multiple
 observations may be returned.}
 
 \item{taxon_id}{Filter by iNat taxon ID. Note that this will also select observations of descendant taxa.}
+
+\item{place_id}{Filter by iNat place ID.}
 
 \item{quality}{The quality grade to be used.  Must be either "casual" or "research".  If left
 blank both will be returned.}


### PR DESCRIPTION
This will add an argument to `get_inat_obs` that allows the user to specify a place_id. Handy if for example you'd like to get all European observations of a species with a global distribution. 

Using the `bounds` argument could be used of course, but as the shape of the area of interest rarely is completely square, you would need to do some kind of spatial filtering after downloading. There is no need to download observations just to filter them out later.